### PR TITLE
feat: 상품 조회 & 검색

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@
     <tr>
         <td><b>회원 탈퇴</b></td>
         <td><span style=background-color:#CE3636AA;font-weight:bold;>DELETE</span></td>
-        <td>/api/profile</span></td>
+        <td>/api/profile</td>
         <td>Authorization</td>
         <td><pre lang="json">{
     "password": String
@@ -152,7 +152,7 @@
     <tr>
         <td><b>단일 상품<br/>조회</b></td>
         <td><span style=background-color:#22741CAA;font-weight:bold;>GET</span></td>
-        <td><span>/api/v1/products?<br/>keyword={keyword}<br/>&minPrice={minPrice}<br/>&isLike={isLike}<br/>&page={page}<br/>&size={size}</span></td>
+        <td><span>/api/products<br/>/{productId}</span></td>
         <td><code>N/A</code></td>
         <td><code>N/A</code></td>
         <td>200</td>
@@ -170,7 +170,7 @@
     <tr>
         <td><b>상품 검색</b></td>
         <td><span style=background-color:#22741CAA;font-weight:bold;>GET</span></td>
-        <td><span>/api/products<br/>/{productId}</span></td>
+        <td><span>/api/v1/products?<br/>keyword={keyword}<br/>&minPrice={minPrice}<br/>&isTrend={isTrend}<br/>&page={page}<br/>&size={size}</span></td>
         <td><code>N/A</code></td>
         <td><code>N/A</code></td>
         <td>200</td>
@@ -208,7 +208,7 @@
         "keyword": "고구마"
       }
     ]  
-}/pre></td>
+}</pre></td>
         <td>
             <span style=background-color:yellow;font-weight:bold;color:black;>200</span>: 성공
         </td>

--- a/docs/goodCrop.sql
+++ b/docs/goodCrop.sql
@@ -6,11 +6,11 @@ BEGIN
     declare keyword VARCHAR(10);
     WHILE idx < 100000
         DO
-            set @keyword = SUBSTR(MD5(RAND()),1,8);
-INSERT INTO search_history(keyword, member_id, created_at)
-VALUES (@keyword, 1, NOW());
-SET idx = idx + 1;
-END WHILE;
+            set @keyword = SUBSTR(MD5(RAND()), 1, 8);
+            INSERT INTO search_history(keyword, member_id, created_at)
+            VALUES (@keyword, 1, NOW());
+            SET idx = idx + 1;
+        END WHILE;
 END$$
 DELIMITER $$
 CALL loopSearchHistoryInsert;

--- a/src/main/java/com/crop/goodcrop/domain/common/dto/PageResponseDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/common/dto/PageResponseDto.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 @Getter
 @Builder
-@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PageResponseDto<T> {

--- a/src/main/java/com/crop/goodcrop/domain/common/dto/PageResponseDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/common/dto/PageResponseDto.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
+@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class PageResponseDto<T> {

--- a/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
 import com.crop.goodcrop.domain.product.entity.Product;
 import com.crop.goodcrop.domain.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,6 +21,8 @@ public class ProductController {
 
     @GetMapping("/products/{productId}")
     public ResponseEntity<ProductResponseDto> retrieveProduct(@PathVariable Long productId) {
-        return ResponseEntity.ok(productService.retrieveProduct(productId));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(productService.retrieveProduct(productId));
     }
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
@@ -1,16 +1,16 @@
 package com.crop.goodcrop.domain.product.controller;
 
 
+import com.crop.goodcrop.domain.common.dto.PageResponseDto;
 import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
-import com.crop.goodcrop.domain.product.entity.Product;
 import com.crop.goodcrop.domain.product.service.ProductService;
+import com.crop.goodcrop.exception.ErrorCode;
+import com.crop.goodcrop.exception.ResponseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -25,4 +25,23 @@ public class ProductController {
                 .status(HttpStatus.OK)
                 .body(productService.retrieveProduct(productId));
     }
+
+    @GetMapping("v1/products")
+    public ResponseEntity<PageResponseDto<ProductResponseDto>> searchProducts(
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "0", required = false) int minPrice,
+            @RequestParam(defaultValue = "false") boolean isTrend,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+            ) {
+
+        // keyword가 공백 또는 빈 문자열인 경우 예외 처리
+        if (keyword.trim().isEmpty()) {
+            throw new ResponseException(ErrorCode.BAD_INPUT, "키워드가 공백이거나 비어있을 수 없습니다.");
+        }
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(productService.searchProducts(keyword, minPrice, isTrend, page, size));
+    }
+
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
@@ -1,4 +1,25 @@
 package com.crop.goodcrop.domain.product.controller;
 
+
+import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
+import com.crop.goodcrop.domain.product.entity.Product;
+import com.crop.goodcrop.domain.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
 public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/products/{productId}")
+    public ResponseEntity<ProductResponseDto> retrieveProduct(@PathVariable Long productId) {
+        return ResponseEntity.ok(productService.retrieveProduct(productId));
+    }
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/dto/response/ProductAvgScoreDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/dto/response/ProductAvgScoreDto.java
@@ -1,0 +1,18 @@
+package com.crop.goodcrop.domain.product.dto.response;
+
+import com.crop.goodcrop.domain.product.entity.Product;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductAvgScoreDto {
+    @JsonProperty("product")
+    private Product product;
+
+    @JsonProperty("avgScore")
+    private Double avgScore;
+}

--- a/src/main/java/com/crop/goodcrop/domain/product/dto/response/ProductResponseDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/dto/response/ProductResponseDto.java
@@ -1,4 +1,16 @@
 package com.crop.goodcrop.domain.product.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ProductResponseDto {
+
+    private Long id;
+    private String name;
+    private int price;
+    private Double avgScore;
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepository.java
@@ -3,5 +3,5 @@ package com.crop.goodcrop.domain.product.repository;
 import com.crop.goodcrop.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ProductRepository extends JpaRepository<Product, Long> {
+public interface ProductRepository extends JpaRepository<Product, Long>, ProductRepositoryQuery {
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
@@ -40,7 +40,7 @@ public class ProductRepositoryImpl implements ProductRepositoryQuery {
         JPAQuery<Product> query = queryFactory
                 .selectFrom(qProduct)
                 .leftJoin(qLike)
-                .on(qProduct.id.eq(qLike.id))
+                .on(qProduct.id.eq(qLike.product.id))
                 .where(whereClause);
 
         // 1) isTrend == true -> 기본정렬은 좋아요 수 내림차순 정렬

--- a/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.crop.goodcrop.domain.product.repository;
+
+import com.crop.goodcrop.domain.like.entity.QLike;
+import com.crop.goodcrop.domain.product.entity.Product;
+import com.crop.goodcrop.domain.product.entity.QProduct;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class ProductRepositoryImpl implements ProductRepositoryQuery {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public Optional<Page<Product>> searchProductsWithFilters(
+            String keyword,
+            int minPrice,
+            boolean isTrend,
+            Pageable pageable
+    ) {
+        QProduct qProduct = QProduct.product;
+        QLike qLike = QLike.like;
+
+        // WHERE 절
+        BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(qProduct.name.containsIgnoreCase(keyword));
+        if (minPrice > 0) {
+            whereClause.and(qProduct.price.goe(minPrice));
+        }
+
+        JPAQuery<Product> query = queryFactory
+                .selectFrom(qProduct)
+                .leftJoin(qLike)
+                .on(qProduct.id.eq(qLike.id))
+                .where(whereClause);
+
+        // 1) isTrend == true -> 기본정렬은 좋아요 수 내림차순 정렬
+        // 2) 가격 오름차순 정렬 / 키워드 오름차순 정렬
+        if (isTrend) {
+            query.groupBy(qProduct.id)
+                    .orderBy(qLike.count().desc());
+        }
+
+        if (minPrice > 0) query.orderBy(qProduct.price.asc());
+        else query.orderBy(qProduct.name.asc());
+
+        // Pageable 적용
+        List<Product> products = query
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 페이지네이션을 위한 전체 데이터 수
+        Long totalCount = queryFactory
+                .select(qProduct.count())
+                .from(qProduct)
+                .leftJoin(qLike)
+                .on(qProduct.id.eq(qLike.id))
+                .where(whereClause)
+                .fetchOne();
+        totalCount = totalCount == null ? 0 : totalCount;
+
+
+        return Optional.ofNullable(
+                products.isEmpty() ? null : new PageImpl<>(products, pageable, totalCount)
+        );
+    }
+
+}

--- a/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryImpl.java
@@ -64,7 +64,7 @@ public class ProductRepositoryImpl implements ProductRepositoryQuery {
                 .select(qProduct.count())
                 .from(qProduct)
                 .leftJoin(qLike)
-                .on(qProduct.id.eq(qLike.id))
+                .on(qProduct.id.eq(qLike.product.id))
                 .where(whereClause)
                 .fetchOne();
         totalCount = totalCount == null ? 0 : totalCount;

--- a/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryQuery.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/repository/ProductRepositoryQuery.java
@@ -1,0 +1,12 @@
+package com.crop.goodcrop.domain.product.repository;
+
+import com.crop.goodcrop.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public interface ProductRepositoryQuery {
+
+    Optional<Page<Product>> searchProductsWithFilters(String keyword, int minPrice, boolean isTrend, Pageable pageable);
+}

--- a/src/main/java/com/crop/goodcrop/domain/product/service/ProductService.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/service/ProductService.java
@@ -1,7 +1,33 @@
 package com.crop.goodcrop.domain.product.service;
 
+import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
+import com.crop.goodcrop.domain.product.entity.Product;
+import com.crop.goodcrop.domain.product.repository.ProductRepository;
+import com.crop.goodcrop.domain.review.repository.ReviewRepository;
+import com.crop.goodcrop.exception.ErrorCode;
+import com.crop.goodcrop.exception.ResponseException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
+@RequiredArgsConstructor
 public class ProductService {
+
+    private final ProductRepository productRepository;
+    private final ReviewRepository reviewRepository;
+
+    public ProductResponseDto retrieveProduct(Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new ResponseException(ErrorCode.PRODUCT_NOT_FOUND));
+        Double avgScore = Optional.ofNullable(reviewRepository.findAverageScoreByProduct(product))
+                .orElse(-1.0);
+
+        return new ProductResponseDto(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                avgScore);
+    }
 }

--- a/src/main/java/com/crop/goodcrop/domain/product/service/ProductService.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/service/ProductService.java
@@ -1,5 +1,7 @@
 package com.crop.goodcrop.domain.product.service;
 
+import com.crop.goodcrop.domain.common.dto.PageResponseDto;
+import com.crop.goodcrop.domain.product.dto.response.ProductAvgScoreDto;
 import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
 import com.crop.goodcrop.domain.product.entity.Product;
 import com.crop.goodcrop.domain.product.repository.ProductRepository;
@@ -7,8 +9,12 @@ import com.crop.goodcrop.domain.review.repository.ReviewRepository;
 import com.crop.goodcrop.exception.ErrorCode;
 import com.crop.goodcrop.exception.ResponseException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -29,5 +35,36 @@ public class ProductService {
                 product.getName(),
                 product.getPrice(),
                 avgScore);
+    }
+
+    public PageResponseDto<ProductResponseDto> searchProducts(String keyword, int minPrice, boolean isTrend, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        Page<Product> products = productRepository.searchProductsWithFilters(keyword, minPrice, isTrend, pageable)
+                .orElseThrow(() -> new ResponseException(ErrorCode.PRODUCT_SEARCH_NOT_FOUND));
+
+        /*
+        성능 문제 발생 예상
+        List<Product> -> List<ProductResponseDto> 의 과정에서 avgScore 필요합니다.
+        1. ProductAvgScoreDto 로 Product, AvgScore 를 review 한번 더 LEFT JOIN 하여 조회
+        2. Stream API 로 List<ProductResponseDto> 생성
+        3. List<ProductResponseDto> 를 PageResponseDto 에 담아 반환
+        최대한 N+1 발생 하지 않기 위해 위 방법을 택했습니다.
+         */
+        List<ProductAvgScoreDto> productResponse = reviewRepository.findProductWithAvgScores(products.getContent());
+        List<ProductResponseDto> respDtos = productResponse.stream()
+                .map(result -> {
+                    Product product = result.getProduct();
+                    Double avgScore = result.getAvgScore() == null ? -1.0 : result.getAvgScore();
+                    return new ProductResponseDto(
+                            product.getId(),
+                            product.getName(),
+                            product.getPrice(),
+                            avgScore
+                    );
+                }).toList();
+        return PageResponseDto.of(
+                respDtos, pageable, products.getTotalPages()
+        );
     }
 }

--- a/src/main/java/com/crop/goodcrop/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/repository/ReviewRepository.java
@@ -1,15 +1,23 @@
 package com.crop.goodcrop.domain.review.repository;
 
+import com.crop.goodcrop.domain.product.dto.response.ProductAvgScoreDto;
 import com.crop.goodcrop.domain.product.entity.Product;
 import com.crop.goodcrop.domain.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findByProductId(Long productId, Pageable pageable);
 
     @Query("SELECT AVG(r.score) FROM Review r WHERE r.product = :product")
     Double findAverageScoreByProduct(Product product);
+
+    @Query("SELECT new com.crop.goodcrop.domain.product.dto.response.ProductAvgScoreDto(p, AVG(r.score))" +
+            "FROM Product p LEFT JOIN FETCH Review r ON p.id = r.product.id WHERE p IN :products GROUP BY p")
+    List<ProductAvgScoreDto> findProductWithAvgScores(@Param("products") List<Product> products);
 }

--- a/src/main/java/com/crop/goodcrop/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/repository/ReviewRepository.java
@@ -1,10 +1,15 @@
 package com.crop.goodcrop.domain.review.repository;
 
+import com.crop.goodcrop.domain.product.entity.Product;
 import com.crop.goodcrop.domain.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Page<Review> findByProductId(Long productId, Pageable pageable);
+
+    @Query("SELECT AVG(r.score) FROM Review r WHERE r.product = :product")
+    Double findAverageScoreByProduct(Product product);
 }

--- a/src/main/java/com/crop/goodcrop/exception/ErrorCode.java
+++ b/src/main/java/com/crop/goodcrop/exception/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     // Product
     PRODUCT_NOT_FOUND("P000", "존재하지 않는 상품입니다", HttpStatus.NOT_FOUND),
+    PRODUCT_SEARCH_NOT_FOUND("P001", "검색 조건에 맞는 상품을 찾을 수 없습니다", HttpStatus.NOT_FOUND),
 
     // Like
     LIKE_NOT_FOUND("L000", "해당 상품에 좋아요를 누르지 않았습니다.", HttpStatus.NOT_FOUND),


### PR DESCRIPTION
- 🔘 담당 파트
  - 상품 조회 & 검색 파트
- 🔎 작업 상세 내용
  - 단일 상품 조회 API 추가
  - 필터링하여 상품을 검색하는 v1 API 추가
  - 검색할 때 페이지 네이션을 구현할 것.
  - 평균 평점이 응답 되도록 할 것.
  - 사용자가 전달한 파라미터에 따른 동적 정렬을 적용
- 🔧 앞으로의 과제
  - In-memory Cache(Local Memory Cache) 적용시킨 v2 검색 API 추가 구현 해야 함.
- ➕ 이슈 링크
  - https://github.com/TeamCrops/good-crop/issues/4