### PR TITLE
 fix: 리뷰 등록/수정/삭제 에 Security 적용, 리뷰 관련 오류 수정

### DIFF
--- a/src/main/java/com/crop/goodcrop/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/controller/ReviewController.java
@@ -6,10 +6,12 @@ import com.crop.goodcrop.domain.review.dto.request.ReviewModifyRequestDto;
 import com.crop.goodcrop.domain.review.dto.response.ReviewResponseDto;
 import com.crop.goodcrop.domain.review.entity.Review;
 import com.crop.goodcrop.domain.review.service.ReviewService;
+import com.crop.goodcrop.security.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -21,14 +23,11 @@ public class ReviewController {
 
     @PostMapping("")
     public ResponseEntity<ReviewResponseDto> writeReview(
-            // TODO
-            //  - Security 적용
-//            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long productId,
             @Valid @RequestBody ReviewCreateRequestDto reviewRequestDto
     ) {
-//        Long memberId = userDetails.getMember().getId();
+        Long memberId = userDetails.getUser().getId();
         ReviewResponseDto reviewResponseDto = reviewService.createReview(memberId, productId, reviewRequestDto);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
@@ -48,15 +47,12 @@ public class ReviewController {
 
     @PutMapping("/{reviewId}")
     public ResponseEntity<ReviewResponseDto> updateReview(
-            // TODO
-            //  - Security 적용
-//            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long productId,
             @PathVariable Long reviewId,
             @Valid @RequestBody ReviewModifyRequestDto reviewRequestDto
     ) {
-//        Long memberId = userDetails.getMember().getId();
+        Long memberId = userDetails.getUser().getId();
         ReviewResponseDto reviewResponseDto = reviewService.modifyReview(memberId, productId, reviewId, reviewRequestDto);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -65,14 +61,11 @@ public class ReviewController {
 
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<ReviewResponseDto> deleteReview(
-            // TODO
-            //  - Security 적용
-//            @AuthenticationPrincipal UserDetailsImpl userDetails,
-            @RequestParam Long memberId,
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long productId,
             @PathVariable Long reviewId
     ) {
-//        Long memberId = userDetails.getMember().getId();
+        Long memberId = userDetails.getUser().getId();
         reviewService.deleteReview(memberId, productId, reviewId);
         return ResponseEntity
                 .status(HttpStatus.NO_CONTENT)

--- a/src/main/java/com/crop/goodcrop/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/controller/ReviewController.java
@@ -4,7 +4,6 @@ import com.crop.goodcrop.domain.common.dto.PageResponseDto;
 import com.crop.goodcrop.domain.review.dto.request.ReviewCreateRequestDto;
 import com.crop.goodcrop.domain.review.dto.request.ReviewModifyRequestDto;
 import com.crop.goodcrop.domain.review.dto.response.ReviewResponseDto;
-import com.crop.goodcrop.domain.review.entity.Review;
 import com.crop.goodcrop.domain.review.service.ReviewService;
 import com.crop.goodcrop.security.entity.UserDetailsImpl;
 import jakarta.validation.Valid;
@@ -35,11 +34,11 @@ public class ReviewController {
     }
 
     @GetMapping("")
-    public ResponseEntity<PageResponseDto<Review>> readReviews(
+    public ResponseEntity<PageResponseDto<ReviewResponseDto>> readReviews(
             @PathVariable Long productId,
             @RequestParam(required = false, defaultValue = "1") int page
     ) {
-        PageResponseDto<Review> responses = reviewService.retrieveReviews(productId, page);
+        PageResponseDto<ReviewResponseDto> responses = reviewService.retrieveReviews(productId, page);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(responses);

--- a/src/main/java/com/crop/goodcrop/domain/review/dto/request/ReviewCreateRequestDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/dto/request/ReviewCreateRequestDto.java
@@ -1,6 +1,6 @@
 package com.crop.goodcrop.domain.review.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +10,7 @@ import org.hibernate.validator.constraints.Range;
 @Getter
 public class ReviewCreateRequestDto {
     // 별점: 최소 1점, 최대 5점
-    @NotBlank
+    @NotNull
     @Range(min=1, max=5)
     private int score;
 

--- a/src/main/java/com/crop/goodcrop/domain/review/dto/request/ReviewModifyRequestDto.java
+++ b/src/main/java/com/crop/goodcrop/domain/review/dto/request/ReviewModifyRequestDto.java
@@ -1,6 +1,6 @@
 package com.crop.goodcrop.domain.review.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,7 +10,7 @@ import org.hibernate.validator.constraints.Range;
 @Getter
 public class ReviewModifyRequestDto {
     // 별점: 최소 1점, 최대 5점
-    @NotBlank
+    @NotNull
     @Range(min=1, max=5)
     private int score;
 

--- a/src/test/java/com/crop/goodcrop/review/ReviewServiceTest.java
+++ b/src/test/java/com/crop/goodcrop/review/ReviewServiceTest.java
@@ -108,7 +108,7 @@ class ReviewServiceTest {
         }
 
         // When
-        PageResponseDto<Review> responses = reviewService.retrieveReviews(product.getId(), 1);
+        PageResponseDto<ReviewResponseDto> responses = reviewService.retrieveReviews(product.getId(), 1);
 
         // Then
         assertThat(responses).isNotNull();


### PR DESCRIPTION
## 🔘 담당 파트
- 리뷰 등록/수정/삭제 에 Security 적용
<br>

## 🔎 작업 상세 내용
### 1. 리뷰 등록/수정/삭제 에 Security 적용

### 2. Request DTO (ReviewCreateRequestDto, ReviewModifyRequestDto)의 제약 조건 수정
- NotBlank의 int 형 타입 제약으로 인한 NotNull로 변경

### 3. 리뷰 조회의 잘못된 response 타입 수정
- PageResponseDto<Review> -> PageResponseDto<ReviewResponseDto>

### 4. 조회하는 retrieveReviews 메서드에 @Transactional(readOnly = true) 추가
- 조회할 때 발생하는 영속성 문제 해결
<br>

## 🔧 앞으로의 과제
- 역할 분담 및 성능 개선
<br>

## ➕ 이슈 링크
- #52 
