### PR TITLE
fix: Security Filter 로직 변경

### DIFF
--- a/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
+++ b/src/main/java/com/crop/goodcrop/domain/product/controller/ProductController.java
@@ -6,9 +6,11 @@ import com.crop.goodcrop.domain.product.dto.response.ProductResponseDto;
 import com.crop.goodcrop.domain.product.service.ProductService;
 import com.crop.goodcrop.exception.ErrorCode;
 import com.crop.goodcrop.exception.ResponseException;
+import com.crop.goodcrop.security.entity.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 
@@ -28,12 +30,15 @@ public class ProductController {
 
     @GetMapping("v1/products")
     public ResponseEntity<PageResponseDto<ProductResponseDto>> searchProducts(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam String keyword,
             @RequestParam(defaultValue = "0", required = false) int minPrice,
             @RequestParam(defaultValue = "false") boolean isTrend,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
             ) {
+        Long memberId = (userDetails != null) ? userDetails.getUser().getId() : -1;
+        System.out.println("memberId: " + memberId);
 
         // keyword가 공백 또는 빈 문자열인 경우 예외 처리
         if (keyword.trim().isEmpty()) {

--- a/src/main/java/com/crop/goodcrop/exception/ErrorCode.java
+++ b/src/main/java/com/crop/goodcrop/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
     // Server(S)
     INTERNAL_SERVER_ERROR("S000","서버 내부 오류", HttpStatus.INTERNAL_SERVER_ERROR),
+    SECURITY_PERMIT_ERROR("S001","Security 인증 오류", HttpStatus.UNAUTHORIZED),
 
     // Common(C)
     UNKNOWN_ERROR("C000","알 수 없는 에러", HttpStatus.INTERNAL_SERVER_ERROR),

--- a/src/main/java/com/crop/goodcrop/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/crop/goodcrop/security/config/WebSecurityConfig.java
@@ -1,9 +1,13 @@
 package com.crop.goodcrop.security.config;
 
+import com.crop.goodcrop.exception.ErrorCode;
+import com.crop.goodcrop.exception.ErrorResponseDto;
 import com.crop.goodcrop.security.filter.JwtAuthenticationFilter;
 import com.crop.goodcrop.security.filter.JwtAuthorizationFilter;
 import com.crop.goodcrop.security.service.UserDetailsServiceImpl;
 import com.crop.goodcrop.security.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,18 +24,20 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @RequiredArgsConstructor
 public class WebSecurityConfig {
+
     private final JwtUtil jwtUtil;
     private final UserDetailsServiceImpl userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
 
-    //AuthenticationManager 빈 설정 (인증 처리)
+    // AuthenticationManager 빈 설정 (인증 처리)
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
     }
 
-    //JwtAuthenticationFilter 빈 설정 (로그인 요청 시 사용자 정보 검증 jwt 생성)
+    // JwtAuthenticationFilter 빈 설정 (로그인 요청 시 사용자 정보 검증 jwt 생성)
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
@@ -39,7 +45,7 @@ public class WebSecurityConfig {
         return filter;
     }
 
-    //JwtAuthorizationFilter 빈 설정 (jwt 유효성 검증, 사용자 인증 상태 설정)
+    // JwtAuthorizationFilter 빈 설정 (jwt 유효성 검증, 사용자 인증 상태 설정)
     @Bean
     public JwtAuthorizationFilter jwtAuthorizationFilter() {
         return new JwtAuthorizationFilter(jwtUtil, userDetailsService);
@@ -48,13 +54,13 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                //csrf 비활성화
+                // csrf 비활성화
                 .csrf(csrf -> csrf.disable())
-                //jwt 방식 사용하기 위한 설정
+                // jwt 방식 사용하기 위한 설정
                 .sessionManagement((sessionManagement) ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
-                //요청 접근 허가
+                // 요청 접근 허가
                 .authorizeHttpRequests(auth ->
                         // 회원가입,로그인
                         auth.requestMatchers("/api/auth/**").permitAll()
@@ -67,7 +73,18 @@ public class WebSecurityConfig {
                                 .requestMatchers("/api/v1/trends").permitAll()
                                 // 리뷰보기
                                 .requestMatchers(HttpMethod.GET, "/api/products/{productId}/reviews").permitAll()
-                                .anyRequest().authenticated() //그 외 모든 요청 인증처리
+                                .anyRequest().authenticated() // 그 외 모든 요청 인증처리
+                )
+                // 인증 실패 처리
+                .exceptionHandling(exceptionHandling ->
+                        exceptionHandling.authenticationEntryPoint((request, response, authException) -> {
+                            // 인증 실패 시 처리할 응답
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401
+                            response.setContentType("application/json;charset=utf-8");
+
+                            String json = objectMapper.writeValueAsString(new ErrorResponseDto(ErrorCode.SECURITY_PERMIT_ERROR, request.getRequestURI()));
+                            response.getWriter().write(json);
+                        })
                 );
 
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/crop/goodcrop/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/crop/goodcrop/security/filter/JwtAuthorizationFilter.java
@@ -41,27 +41,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        String url = httpRequest.getRequestURI();
-        String method = httpRequest.getMethod();
-        // 허용된 URL
-        if (url.startsWith("/api/auth") || //회원가입,로그인
-                (url.matches("/api/products/\\d+") && "GET".equals(method)) || //단일 상품 조회
-                url.startsWith("/api/v1/products") || //상품검색
-                url.startsWith("/api/trends") || //인기 검색어
-                url.startsWith("/api/v1/trends") || //인기 검색어
-                (url.matches("/api/products/\\d+/reviews") && "GET".equals(method))//리뷰보기
-        ) {
-            chain.doFilter(request, response);
-            return;
-        }
-        log.info("현재 url = {}", url);
-
         // JWT 검증 로직 수행
         String bearerJwt = httpRequest.getHeader("Authorization");
 
         // 토큰 없음
         if (bearerJwt == null) {
-            sendErrorResponse(httpResponse, ErrorCode.TOKEN_MISSING,request);
+            chain.doFilter(request, response);
             return;
         }
 


### PR DESCRIPTION
🔘 담당 파트
- Security 파트

🔎 작업 상세 내용
- 비회원과 회원이 검색을 할 때 UserDetails 를 가지도록 Security Filter 검증 단계에서 전 Url이 jwt에 대한 검증 하도록 변경
- 만약 인증이 실패할 시 exceptionHandling을 WebSecurityConfig 에서 처리하도록 변경
- 예시로 ProductController 의 searchProducts 메서드에서 비회원은 -1, 회원은 회원 고유 식별 id를 갖도록 처리 예시 추가

🔧 앞으로의 과제
- search_history 테이블에 비회원도 user_id를 잘 적재할 수 있게 활용해야 함

➕ 이슈 링크
- #61